### PR TITLE
Arguments for Key and Header Length

### DIFF
--- a/NemucodFR.py
+++ b/NemucodFR.py
@@ -1,47 +1,44 @@
 """
-
 Nemucod File Recovery
-
 Coded by Antelox
 Twitter: @Antelox
 UIC R.E. Academy - quequero.org
-
 Released under MIT License
-
 This script is able to recover encrypted files by Nemucod Ransomware (last variant)
-
 For more informations about this variant you can take a look at:
-
 https://glot.io/snippets/ee7hiif87k
-
 DISCLAIMER
 Use this script at your own risk. I'm not responsible for any data loss!
 Anyway the script doesn't overwrite and/or delete any files.
-
 """
 
 import sys
 import glob
 import os
 
-def decrypt(file, key):
+def decrypt(file, key, header_size = None):
+	if header_size is None:
+		header_size = 1024
+	print header_size
 	try:
 		fencrypted = open(file, 'rb')
 		
 		content_encrypted = fencrypted.read()
 		filesize = len(content_encrypted)
-		
+		keylen = len(key)
+
 		recovered = ''
 		full_recovered = ''
 		
-		if filesize <= 1024:
+		if filesize <= header_size:
 			for i in range(0,filesize):
-				recovered = recovered + chr(ord(content_encrypted[i])^ord(key[i%36]))
+				print filesize
+				recovered = recovered + chr(ord(content_encrypted[i])^ord(key[i%keylen]))
 			full_recovered = recovered
 		else:
-			for i in range(0,1024):
-				recovered = recovered + chr(ord(content_encrypted[i])^ord(key[i%36]))
-			full_recovered = recovered + content_encrypted[1024:]
+			for i in range(0,header_size):
+				recovered = recovered + chr(ord(content_encrypted[i])^ord(key[i%keylen]))
+			full_recovered = recovered + content_encrypted[header_size:]
 		
 		open(file[:-8], 'wb').write(full_recovered)
 		fencrypted.close()
@@ -53,12 +50,16 @@ def decrypt(file, key):
 #main
 print "\n*Nemucod File Recovery*\n"
 
-if len(sys.argv) == 3:
+if len(sys.argv) >= 3:
 	os.chdir(sys.argv[1])
-	for file in glob.glob("*.crypted"):
-		decrypt(file,sys.argv[2])
+	if len(sys.argv) == 3:
+		for file in glob.glob("*.crypted"):
+			decrypt(file,sys.argv[2])
+	else:
+		for file in glob.glob("*.crypted"):
+			decrypt(file,sys.argv[2],int(sys.argv[3]))
 else:
 	print "*ERROR: Incorrect number of arguments passed to the script!\n"
-	print "Example: python NemucodFR.py folder key\n"
+	print "Example: python NemucodFR.py folder key [header_size]\n"
 	print "folder: a folder which contains encrypted files by Nemucod with .crypted extension;\n"
 	print "key: the key recovered with the crack.py script."

--- a/NemucodFR.py
+++ b/NemucodFR.py
@@ -19,7 +19,7 @@ import os
 def decrypt(file, key, header_size = None):
 	if header_size is None:
 		header_size = 1024
-	print header_size
+
 	try:
 		fencrypted = open(file, 'rb')
 		

--- a/NemucodKE.py
+++ b/NemucodKE.py
@@ -1,38 +1,35 @@
 """
-
 Nemucod Key Extractor
-
 Coded by Antelox
 Twitter: @Antelox
 UIC R.E. Academy - quequero.org
-
 Released under MIT License
-
 This script is designed to work with the last variant of Nemucod Ransomware. For more informations you can take a look here:
-
 https://glot.io/snippets/ee7hiif87k
-
-
 DISCLAIMER
 Use this script at your own risk. I'm not responsible for any data loss!
 Anyway this script print only the key extracted. No file operations will be performed.
-
 """
 
 import sys
 
 print "\n*Nemucod Key Extractor*\n"
 
-if len(sys.argv)== 3:
+if len(sys.argv) == 4:
+	keylen = int(sys.argv[3])
+else:
+	keylen = 36
+
+if len(sys.argv) >= 3:
 	fencrypted = open(sys.argv[1],'rb')
 	fplain = open(sys.argv[2],'rb')
 
-	content_encrypted = fencrypted.read(36)
-	content_plain = fplain.read(36)
+	content_encrypted = fencrypted.read(keylen)
+	content_plain = fplain.read(keylen)
 
 	key = ''
 
-	for i in range(0,36):
+	for i in range(0,keylen):
 		key = key + chr(ord(content_encrypted[i])^ord(content_plain[i]))
 
 	print "\n*KEY FOUND*: The key is: %s" % key
@@ -41,6 +38,6 @@ if len(sys.argv)== 3:
 	fplain.close()
 else:
 	print "*ERROR: Incorrect number of arguments passed to the script!\n"
-	print "Example: python NemucodKE.py encrypted original\n"
+	print "Example: python NemucodKE.py encrypted original [keylen]\n"
 	print "encrypted: a file encrypted by Nemucod with .crypted extension;\n"
 	print "original: the same file not encrypted of which you have a backup copy."


### PR DESCRIPTION
Found a victim with 255-byte key and 2048 byte header "encryption". Added ability to pass the length of the key for key extraction, and length of the encrypted header for file recovery.
